### PR TITLE
Add missing parameter documentation to hx.supports

### DIFF
--- a/content/modules/util/versions/0.9.0.um
+++ b/content/modules/util/versions/0.9.0.um
@@ -53,6 +53,7 @@
     @function hx.supports
       @description
         Provides a way to find out if the browser supports a feature.
+      @param name [String]: The name of the feature to check
 
         @codeblock js
           // this is the list of checks that are currently available


### PR DESCRIPTION
Currently `hx.supports` is listed as having no parameters.
