### PR TITLE
Add a 404 page

### DIFF
--- a/build/index.js
+++ b/build/index.js
@@ -305,6 +305,7 @@ function startServer () {
   liveServer.start({
     port: 9000,
     root: 'target',
+    file: '404/index.html',
     wait: 50,
     open: false
   })

--- a/content/pages/404/index.um
+++ b/content/pages/404/index.um
@@ -1,0 +1,11 @@
+@inline ../../shared/common.um
+@titlebar 404
+
+@div .dx-error-message
+  @div .dx-error-message-heading: 404
+  @p: The content you requested was not found
+  @div
+    @button .dx-btn.dx-action: Go Back
+      @attr onclick: javascript:window.history.back()
+    @a .dx-btn.dx-action: Go to Home Page
+      @attr href: /

--- a/server/server.py
+++ b/server/server.py
@@ -13,6 +13,7 @@ class Content(webapp2.RequestHandler):
   def get(self, *args, **kwargs):
     urlPath = args[0]
     root = os.path.split(__file__)[0]
+    errorPath = os.path.join(root, '404', 'index.html')
     try:
       paths = [
         os.path.join(root, urlPath + '.html'),
@@ -25,7 +26,7 @@ class Content(webapp2.RequestHandler):
       if len(validPaths) > 0:
         path = validPaths[0]
       else:
-        path = os.path.join(os.path.split(__file__)[0], '404.html')
+        path = errorPath
         self.response.set_status(404)
 
       if path.endswith(".css"):
@@ -50,8 +51,10 @@ class Content(webapp2.RequestHandler):
         self.response.out.write(content)
     except:
       logging.exception("unable to serve page")
-      path = os.path.join(os.path.split(__file__)[0], '404.html')
+      path = errorPath
       f = open(path, 'r')
+      content = f.read()
+      self.response.out.write(content)
       self.response.set_status(404)
 
 app = WSGIApplication([


### PR DESCRIPTION
Changes to fix #18. I've tested it to work using both the live-server and app engine. I did have to make some small changes to server.py since this was expecting the 404 page to be at the wrong path, and wasn't serving the 404 page content if an error was thrown.
