### PR TITLE
Update url behaviour

### DIFF
--- a/build/index.js
+++ b/build/index.js
@@ -17,6 +17,7 @@ var Progress = require('progress')
 var chalk = require('chalk')
 var watch = require('quantum-watch')
 var flatten = require('flatten')
+var liveServer = require('live-server')
 
 var privateConfig
 try {
@@ -265,7 +266,6 @@ function getOptions (dev) {
     indexable: indexable,
     unmergeable: ['examples', 'description', 'extra'],
     filenameModifier: filenameModifier,
-    outputLatest: false,
     versions: versions.versions,
     targetVersions: targetVersions
   }
@@ -331,7 +331,13 @@ function buildOnce () {
 }
 
 function startServer () {
-  require('child_process').spawn('dev_appserver.py', ['--port=9000', '--host=0.0.0.0', 'target/app.yaml'], { stdio: 'inherit' })
+  liveServer.start({
+    port: 9000,
+    root: 'target',
+    file: '404/index.html',
+    wait: 50,
+    open: false
+  })
 }
 
 if (process.argv[2] === 'postinstall') {

--- a/build/index.js
+++ b/build/index.js
@@ -17,7 +17,6 @@ var Progress = require('progress')
 var chalk = require('chalk')
 var watch = require('quantum-watch')
 var flatten = require('flatten')
-var liveServer = require('live-server')
 
 var privateConfig
 try {
@@ -104,8 +103,15 @@ function copyResources () {
     fs.copyAsync('node_modules/font-awesome/css/', 'target/resources/font-awesome/css/'),
     fs.copyAsync('node_modules/font-awesome/fonts/', 'target/resources/font-awesome/fonts/'),
     fs.copyAsync('content/resources/', 'target/resources/'),
-    fs.copyAsync('server/', 'target/')
+    copyServer()
   ])
+}
+
+function copyServer () {
+  return fs.copyAsync('server/', 'target/')
+    .then(() => fs.readFileAsync('target/server.py', 'utf-8'))
+    .then((contents) => contents.replace('__latestVersion__', versions.latest))
+    .then((contents) => fs.outputFileAsync('target/server.py', contents))
 }
 
 function getTemplateVariables (dev) {
@@ -325,13 +331,7 @@ function buildOnce () {
 }
 
 function startServer () {
-  liveServer.start({
-    port: 9000,
-    root: 'target',
-    file: '404/index.html',
-    wait: 50,
-    open: false
-  })
+  require('child_process').spawn('dev_appserver.py', ['--port=9000', '--host=0.0.0.0', 'target/app.yaml'], { stdio: 'inherit' })
 }
 
 if (process.argv[2] === 'postinstall') {

--- a/build/index.js
+++ b/build/index.js
@@ -104,15 +104,8 @@ function copyResources () {
     fs.copyAsync('node_modules/font-awesome/css/', 'target/resources/font-awesome/css/'),
     fs.copyAsync('node_modules/font-awesome/fonts/', 'target/resources/font-awesome/fonts/'),
     fs.copyAsync('content/resources/', 'target/resources/'),
-    copyServer()
+    fs.copyAsync('server/', 'target/')
   ])
-}
-
-function copyServer () {
-  return fs.copyAsync('server/', 'target/')
-    .then(() => fs.readFileAsync('target/server.py', 'utf-8'))
-    .then((contents) => contents.replace('__latestVersion__', versions.latest))
-    .then((contents) => fs.outputFileAsync('target/server.py', contents))
 }
 
 function getTemplateVariables (dev) {

--- a/content/resources/titlebar.js
+++ b/content/resources/titlebar.js
@@ -59,7 +59,7 @@ function setupMenu (node, meta) {
     groupsObj[name].forEach(function (module) {
       groupModulesContainer.add(dx.detached('a')
         .class('docs-dropdown-module-link dx-section dx-fixed')
-        .attr('href', '/docs/' + (meta.selectedVersion || meta.targetVersions[meta.targetVersions.length - 1]) + '/' + module + '/')
+        .attr('href', '/docs/' + (meta.selectedVersion ? meta.selectedVersion + '/' : '') + module + '/')
         .text(module.split('-').map(function (d) {
           return d[0].toUpperCase() + d.substring(1)
         }).join(' '))
@@ -80,7 +80,7 @@ dx.json('/meta.json', function (err, meta) {
     }
   }
 
-  if (meta.selectedVersion) {
+  if (window.location.pathname.indexOf('/docs/') > -1) {
     dx.select('.docs-version').classed('docs-visible', true)
     var versionPicker = new dx.Picker('.docs-version-button', {
       items: meta.targetVersions.reverse(),
@@ -90,11 +90,15 @@ dx.json('/meta.json', function (err, meta) {
 
         if (!elem.classed('dx-picker-text')) {
           elem.on('click', function () {
-            window.location.assign(window.location.href.replace(meta.selectedVersion, v))
+            if (meta.selectedVersion) {
+              window.location.assign(window.location.href.replace(meta.selectedVersion, v))
+            } else {
+              window.location.assign(window.location.href.replace('docs/', 'docs/' + v + '/'))
+            }
           })
         }
       },
-      value: meta.selectedVersion
+      value: meta.selectedVersion || meta.latest
     })
     dx.select('.docs-version-button').classed('dx-btn', false)
   }

--- a/content/resources/titlebar.js
+++ b/content/resources/titlebar.js
@@ -80,7 +80,7 @@ dx.json('/meta.json', function (err, meta) {
     }
   }
 
-  if (window.location.pathname.indexOf('/docs/') > -1) {
+  if (window.location.pathname.indexOf('/docs/') > -1 && window.location.pathname.indexOf('changelog') === -1) {
     dx.select('.docs-version').classed('docs-visible', true)
     var versionPicker = new dx.Picker('.docs-version-button', {
       items: meta.targetVersions.reverse(),

--- a/server/server.py
+++ b/server/server.py
@@ -19,6 +19,7 @@ class Content(webapp2.RequestHandler):
         os.path.join(root, urlPath + '.html'),
         os.path.join(root, urlPath + 'index.html'),
         os.path.join(root, urlPath + '/index.html'),
+        os.path.join(root, urlPath.replace('docs/','docs/__latestVersion__/') + '/index.html'),
         os.path.join(root, urlPath)
       ]
 

--- a/server/server.py
+++ b/server/server.py
@@ -19,7 +19,6 @@ class Content(webapp2.RequestHandler):
         os.path.join(root, urlPath + '.html'),
         os.path.join(root, urlPath + 'index.html'),
         os.path.join(root, urlPath + '/index.html'),
-        os.path.join(root, urlPath.replace('docs/','docs/__latestVersion__/') + '/index.html'),
         os.path.join(root, urlPath)
       ]
 


### PR DESCRIPTION
Update the behaviour of the docs such that `/docs/<module>` is a valid url that points to `/docs/<latest>/<module>` (e.g. `/docs/base` === `/docs/1.4.2/base`)

This could be done by creating additional files in the /docs/ folder, however it's probably better to redirect to the latest version to prevent duplication and adding unnecessary bloat to the file system.

Part of the requirement for this is changing to use `dev_appserver.py` to run a local version of the gcloud app, as opposed to using `live-server` which means losing live-reload.
It also adds a lot of logging...
