### PR TITLE
Update tags example to use new API

### DIFF
--- a/content/modules/component/versions/1.0.0.um
+++ b/content/modules/component/versions/1.0.0.um
@@ -10,7 +10,7 @@
 
         hx.select('#my-button').on('click', function(){
           var tagInput = hx.component('#my-tag-input')
-          hx.notify().info('Tags: ' + tagInput.tags().join(', '))
+          hx.notify.info('Tags: ' + tagInput.items().join(', '))
         })
 
     @example


### PR DESCRIPTION
Example with `tagInput` doesn't work because:
1) Using old `tagInput.tags()` instead of new `tagInput.items()`.
2) Using old `hx.notify().info()` instead of new `hx.notify.info()`.
With these changes code works ok if I run it from Chrome console.
