### PR TITLE
add keywords to the docs to help improve seo

### DIFF
--- a/build/setupdocs.js
+++ b/build/setupdocs.js
@@ -3,13 +3,24 @@ var path = require('path')
 var fs = Promise.promisifyAll(require('fs-extra'))
 var util = require('./util')
 
-util.moduleList().map(function (module) {
-  var niceModuleName = module.split('-').map(function (part) {return part[0].toUpperCase() + part.slice(1)}).join(' ')
+util.moduleList().then((moduleList) => {
+  return Promise.all(moduleList.map(function (moduleName) {
+    return fs.readJsonAsync(path.join(util.toModuleDir(moduleName), 'module.json'))
+  }))
+}).map((moduleMeta) => {
+  var module = moduleMeta.id
+  var keywords = moduleMeta.keywords
+  var category = moduleMeta.category
+  var niceModuleName = module.split('-').map(function (part) {
+    return part[0].toUpperCase() + part.slice(1)
+  }).join(' ')
   var indexFilename = 'content/pages/modules/' + module + '/index.um'
+  var pageKeywords = `${keywords.join(' ')} ${category}`
   var indexContent = [
     '@stylesheet /resources/hexagon/__version__/hexagon.css',
     '@script /resources/hexagon/__version__/hexagon.js',
     '@inline ../../../shared/common.um',
+    '@keywords ' + pageKeywords,
     '@titlebar ' + niceModuleName,
     '',
     '@div .dx-content',

--- a/content/pages/index.um
+++ b/content/pages/index.um
@@ -2,6 +2,8 @@
 @script /resources/hexagon/{{version}}/hexagon.js
 @inline ../shared/common.um
 
+@keywords [hexagon js, modular themeable collection of components for modern browsers]
+
 @titlebar
 
 @coffee: @inline index.coffee

--- a/content/pages/modules/animate/index.um
+++ b/content/pages/modules/animate/index.um
@@ -1,6 +1,7 @@
 @stylesheet /resources/hexagon/__version__/hexagon.css
 @script /resources/hexagon/__version__/hexagon.js
 @inline ../../../shared/common.um
+@keywords animate util
 @titlebar Animate
 
 @div .dx-content

--- a/content/pages/modules/autocomplete-picker/index.um
+++ b/content/pages/modules/autocomplete-picker/index.um
@@ -1,6 +1,7 @@
 @stylesheet /resources/hexagon/__version__/hexagon.css
 @script /resources/hexagon/__version__/hexagon.js
 @inline ../../../shared/common.um
+@keywords autocomplete complete typeahead suggestion component
 @titlebar Autocomplete Picker
 
 @div .dx-content

--- a/content/pages/modules/autocomplete/index.um
+++ b/content/pages/modules/autocomplete/index.um
@@ -1,6 +1,7 @@
 @stylesheet /resources/hexagon/__version__/hexagon.css
 @script /resources/hexagon/__version__/hexagon.js
 @inline ../../../shared/common.um
+@keywords autocomplete complete typeahead suggestion component
 @titlebar Autocomplete
 
 @div .dx-content

--- a/content/pages/modules/base/index.um
+++ b/content/pages/modules/base/index.um
@@ -1,6 +1,7 @@
 @stylesheet /resources/hexagon/__version__/hexagon.css
 @script /resources/hexagon/__version__/hexagon.js
 @inline ../../../shared/common.um
+@keywords base styles
 @titlebar Base
 
 @div .dx-content

--- a/content/pages/modules/button-group/index.um
+++ b/content/pages/modules/button-group/index.um
@@ -1,6 +1,7 @@
 @stylesheet /resources/hexagon/__version__/hexagon.css
 @script /resources/hexagon/__version__/hexagon.js
 @inline ../../../shared/common.um
+@keywords button group component
 @titlebar Button Group
 
 @div .dx-content

--- a/content/pages/modules/button/index.um
+++ b/content/pages/modules/button/index.um
@@ -1,6 +1,7 @@
 @stylesheet /resources/hexagon/__version__/hexagon.css
 @script /resources/hexagon/__version__/hexagon.js
 @inline ../../../shared/common.um
+@keywords button styles
 @titlebar Button
 
 @div .dx-content

--- a/content/pages/modules/card/index.um
+++ b/content/pages/modules/card/index.um
@@ -1,6 +1,7 @@
 @stylesheet /resources/hexagon/__version__/hexagon.css
 @script /resources/hexagon/__version__/hexagon.js
 @inline ../../../shared/common.um
+@keywords card component
 @titlebar Card
 
 @div .dx-content

--- a/content/pages/modules/click-detector/index.um
+++ b/content/pages/modules/click-detector/index.um
@@ -1,6 +1,7 @@
 @stylesheet /resources/hexagon/__version__/hexagon.css
 @script /resources/hexagon/__version__/hexagon.js
 @inline ../../../shared/common.um
+@keywords click detector util
 @titlebar Click Detector
 
 @div .dx-content

--- a/content/pages/modules/collapsible/index.um
+++ b/content/pages/modules/collapsible/index.um
@@ -1,6 +1,7 @@
 @stylesheet /resources/hexagon/__version__/hexagon.css
 @script /resources/hexagon/__version__/hexagon.js
 @inline ../../../shared/common.um
+@keywords collapsible component
 @titlebar Collapsible
 
 @div .dx-content

--- a/content/pages/modules/color-picker/index.um
+++ b/content/pages/modules/color-picker/index.um
@@ -1,6 +1,7 @@
 @stylesheet /resources/hexagon/__version__/hexagon.css
 @script /resources/hexagon/__version__/hexagon.js
 @inline ../../../shared/common.um
+@keywords color picker component
 @titlebar Color Picker
 
 @div .dx-content

--- a/content/pages/modules/color-scale/index.um
+++ b/content/pages/modules/color-scale/index.um
@@ -1,6 +1,7 @@
 @stylesheet /resources/hexagon/__version__/hexagon.css
 @script /resources/hexagon/__version__/hexagon.js
 @inline ../../../shared/common.um
+@keywords color scale util
 @titlebar Color Scale
 
 @div .dx-content

--- a/content/pages/modules/color/index.um
+++ b/content/pages/modules/color/index.um
@@ -1,6 +1,7 @@
 @stylesheet /resources/hexagon/__version__/hexagon.css
 @script /resources/hexagon/__version__/hexagon.js
 @inline ../../../shared/common.um
+@keywords color util
 @titlebar Color
 
 @div .dx-content

--- a/content/pages/modules/component/index.um
+++ b/content/pages/modules/component/index.um
@@ -1,6 +1,7 @@
 @stylesheet /resources/hexagon/__version__/hexagon.css
 @script /resources/hexagon/__version__/hexagon.js
 @inline ../../../shared/common.um
+@keywords component util
 @titlebar Component
 
 @div .dx-content

--- a/content/pages/modules/crumbtrail/index.um
+++ b/content/pages/modules/crumbtrail/index.um
@@ -1,6 +1,7 @@
 @stylesheet /resources/hexagon/__version__/hexagon.css
 @script /resources/hexagon/__version__/hexagon.js
 @inline ../../../shared/common.um
+@keywords crumbtrail component
 @titlebar Crumbtrail
 
 @div .dx-content

--- a/content/pages/modules/dashboard/index.um
+++ b/content/pages/modules/dashboard/index.um
@@ -1,6 +1,7 @@
 @stylesheet /resources/hexagon/__version__/hexagon.css
 @script /resources/hexagon/__version__/hexagon.js
 @inline ../../../shared/common.um
+@keywords dashboard component
 @titlebar Dashboard
 
 @div .dx-content

--- a/content/pages/modules/data-table/index.um
+++ b/content/pages/modules/data-table/index.um
@@ -1,6 +1,7 @@
 @stylesheet /resources/hexagon/__version__/hexagon.css
 @script /resources/hexagon/__version__/hexagon.js
 @inline ../../../shared/common.um
+@keywords data table component
 @titlebar Data Table
 
 @div .dx-content

--- a/content/pages/modules/date-picker/index.um
+++ b/content/pages/modules/date-picker/index.um
@@ -1,6 +1,7 @@
 @stylesheet /resources/hexagon/__version__/hexagon.css
 @script /resources/hexagon/__version__/hexagon.js
 @inline ../../../shared/common.um
+@keywords date picker component
 @titlebar Date Picker
 
 @div .dx-content

--- a/content/pages/modules/date-time-picker/index.um
+++ b/content/pages/modules/date-time-picker/index.um
@@ -1,6 +1,7 @@
 @stylesheet /resources/hexagon/__version__/hexagon.css
 @script /resources/hexagon/__version__/hexagon.js
 @inline ../../../shared/common.um
+@keywords date time picker component
 @titlebar Date Time Picker
 
 @div .dx-content

--- a/content/pages/modules/drag-container/index.um
+++ b/content/pages/modules/drag-container/index.um
@@ -1,6 +1,7 @@
 @stylesheet /resources/hexagon/__version__/hexagon.css
 @script /resources/hexagon/__version__/hexagon.js
 @inline ../../../shared/common.um
+@keywords drag container draggable drop component
 @titlebar Drag Container
 
 @div .dx-content

--- a/content/pages/modules/drawing/index.um
+++ b/content/pages/modules/drawing/index.um
@@ -1,6 +1,7 @@
 @stylesheet /resources/hexagon/__version__/hexagon.css
 @script /resources/hexagon/__version__/hexagon.js
 @inline ../../../shared/common.um
+@keywords drawing component
 @titlebar Drawing
 
 @div .dx-content

--- a/content/pages/modules/dropdown/index.um
+++ b/content/pages/modules/dropdown/index.um
@@ -1,6 +1,7 @@
 @stylesheet /resources/hexagon/__version__/hexagon.css
 @script /resources/hexagon/__version__/hexagon.js
 @inline ../../../shared/common.um
+@keywords dropdown component
 @titlebar Dropdown
 
 @div .dx-content

--- a/content/pages/modules/error-pages/index.um
+++ b/content/pages/modules/error-pages/index.um
@@ -1,6 +1,7 @@
 @stylesheet /resources/hexagon/__version__/hexagon.css
 @script /resources/hexagon/__version__/hexagon.js
 @inline ../../../shared/common.um
+@keywords error pages styles
 @titlebar Error Pages
 
 @div .dx-content

--- a/content/pages/modules/event-emitter/index.um
+++ b/content/pages/modules/event-emitter/index.um
@@ -1,6 +1,7 @@
 @stylesheet /resources/hexagon/__version__/hexagon.css
 @script /resources/hexagon/__version__/hexagon.js
 @inline ../../../shared/common.um
+@keywords event emitter util
 @titlebar Event Emitter
 
 @div .dx-content

--- a/content/pages/modules/extended-table/index.um
+++ b/content/pages/modules/extended-table/index.um
@@ -1,6 +1,7 @@
 @stylesheet /resources/hexagon/__version__/hexagon.css
 @script /resources/hexagon/__version__/hexagon.js
 @inline ../../../shared/common.um
+@keywords extended table component
 @titlebar Extended Table
 
 @div .dx-content

--- a/content/pages/modules/fast-click/index.um
+++ b/content/pages/modules/fast-click/index.um
@@ -1,6 +1,7 @@
 @stylesheet /resources/hexagon/__version__/hexagon.css
 @script /resources/hexagon/__version__/hexagon.js
 @inline ../../../shared/common.um
+@keywords fast click util
 @titlebar Fast Click
 
 @div .dx-content

--- a/content/pages/modules/file-input/index.um
+++ b/content/pages/modules/file-input/index.um
@@ -1,6 +1,7 @@
 @stylesheet /resources/hexagon/__version__/hexagon.css
 @script /resources/hexagon/__version__/hexagon.js
 @inline ../../../shared/common.um
+@keywords file input upload component
 @titlebar File Input
 
 @div .dx-content

--- a/content/pages/modules/filter/index.um
+++ b/content/pages/modules/filter/index.um
@@ -1,6 +1,7 @@
 @stylesheet /resources/hexagon/__version__/hexagon.css
 @script /resources/hexagon/__version__/hexagon.js
 @inline ../../../shared/common.um
+@keywords filter util
 @titlebar Filter
 
 @div .dx-content

--- a/content/pages/modules/fluid/index.um
+++ b/content/pages/modules/fluid/index.um
@@ -1,6 +1,7 @@
 @stylesheet /resources/hexagon/__version__/hexagon.css
 @script /resources/hexagon/__version__/hexagon.js
 @inline ../../../shared/common.um
+@keywords fluid api detached component
 @titlebar Fluid
 
 @div .dx-content

--- a/content/pages/modules/form-builder/index.um
+++ b/content/pages/modules/form-builder/index.um
@@ -1,6 +1,7 @@
 @stylesheet /resources/hexagon/__version__/hexagon.css
 @script /resources/hexagon/__version__/hexagon.js
 @inline ../../../shared/common.um
+@keywords form builder component
 @titlebar Form Builder
 
 @div .dx-content

--- a/content/pages/modules/form/index.um
+++ b/content/pages/modules/form/index.um
@@ -1,6 +1,7 @@
 @stylesheet /resources/hexagon/__version__/hexagon.css
 @script /resources/hexagon/__version__/hexagon.js
 @inline ../../../shared/common.um
+@keywords form styles
 @titlebar Form
 
 @div .dx-content

--- a/content/pages/modules/format/index.um
+++ b/content/pages/modules/format/index.um
@@ -1,6 +1,7 @@
 @stylesheet /resources/hexagon/__version__/hexagon.css
 @script /resources/hexagon/__version__/hexagon.js
 @inline ../../../shared/common.um
+@keywords format string util
 @titlebar Format
 
 @div .dx-content

--- a/content/pages/modules/inline-editable/index.um
+++ b/content/pages/modules/inline-editable/index.um
@@ -1,6 +1,7 @@
 @stylesheet /resources/hexagon/__version__/hexagon.css
 @script /resources/hexagon/__version__/hexagon.js
 @inline ../../../shared/common.um
+@keywords inline editable input component
 @titlebar Inline Editable
 
 @div .dx-content

--- a/content/pages/modules/inline-picker/index.um
+++ b/content/pages/modules/inline-picker/index.um
@@ -1,6 +1,7 @@
 @stylesheet /resources/hexagon/__version__/hexagon.css
 @script /resources/hexagon/__version__/hexagon.js
 @inline ../../../shared/common.um
+@keywords inline select component
 @titlebar Inline Picker
 
 @div .dx-content

--- a/content/pages/modules/inline-select/index.um
+++ b/content/pages/modules/inline-select/index.um
@@ -1,6 +1,7 @@
 @stylesheet /resources/hexagon/__version__/hexagon.css
 @script /resources/hexagon/__version__/hexagon.js
 @inline ../../../shared/common.um
+@keywords inline select component
 @titlebar Inline Select
 
 @div .dx-content

--- a/content/pages/modules/input-group/index.um
+++ b/content/pages/modules/input-group/index.um
@@ -1,6 +1,7 @@
 @stylesheet /resources/hexagon/__version__/hexagon.css
 @script /resources/hexagon/__version__/hexagon.js
 @inline ../../../shared/common.um
+@keywords input group grouped join styles
 @titlebar Input Group
 
 @div .dx-content

--- a/content/pages/modules/interpolate/index.um
+++ b/content/pages/modules/interpolate/index.um
@@ -1,6 +1,7 @@
 @stylesheet /resources/hexagon/__version__/hexagon.css
 @script /resources/hexagon/__version__/hexagon.js
 @inline ../../../shared/common.um
+@keywords interpolate tween util
 @titlebar Interpolate
 
 @div .dx-content

--- a/content/pages/modules/label/index.um
+++ b/content/pages/modules/label/index.um
@@ -1,6 +1,7 @@
 @stylesheet /resources/hexagon/__version__/hexagon.css
 @script /resources/hexagon/__version__/hexagon.js
 @inline ../../../shared/common.um
+@keywords label tag badge styles
 @titlebar Label
 
 @div .dx-content

--- a/content/pages/modules/layout/index.um
+++ b/content/pages/modules/layout/index.um
@@ -1,6 +1,7 @@
 @stylesheet /resources/hexagon/__version__/hexagon.css
 @script /resources/hexagon/__version__/hexagon.js
 @inline ../../../shared/common.um
+@keywords layout position structure styles
 @titlebar Layout
 
 @div .dx-content

--- a/content/pages/modules/list/index.um
+++ b/content/pages/modules/list/index.um
@@ -1,6 +1,7 @@
 @stylesheet /resources/hexagon/__version__/hexagon.css
 @script /resources/hexagon/__version__/hexagon.js
 @inline ../../../shared/common.um
+@keywords list collection util
 @titlebar List
 
 @div .dx-content

--- a/content/pages/modules/logo/index.um
+++ b/content/pages/modules/logo/index.um
@@ -1,6 +1,7 @@
 @stylesheet /resources/hexagon/__version__/hexagon.css
 @script /resources/hexagon/__version__/hexagon.js
 @inline ../../../shared/common.um
+@keywords logo icon styles
 @titlebar Logo
 
 @div .dx-content

--- a/content/pages/modules/map/index.um
+++ b/content/pages/modules/map/index.um
@@ -1,6 +1,7 @@
 @stylesheet /resources/hexagon/__version__/hexagon.css
 @script /resources/hexagon/__version__/hexagon.js
 @inline ../../../shared/common.um
+@keywords map collection util
 @titlebar Map
 
 @div .dx-content

--- a/content/pages/modules/menu/index.um
+++ b/content/pages/modules/menu/index.um
@@ -1,6 +1,7 @@
 @stylesheet /resources/hexagon/__version__/hexagon.css
 @script /resources/hexagon/__version__/hexagon.js
 @inline ../../../shared/common.um
+@keywords menu list component
 @titlebar Menu
 
 @div .dx-content

--- a/content/pages/modules/meter/index.um
+++ b/content/pages/modules/meter/index.um
@@ -1,6 +1,7 @@
 @stylesheet /resources/hexagon/__version__/hexagon.css
 @script /resources/hexagon/__version__/hexagon.js
 @inline ../../../shared/common.um
+@keywords meter progress component
 @titlebar Meter
 
 @div .dx-content

--- a/content/pages/modules/modal/index.um
+++ b/content/pages/modules/modal/index.um
@@ -1,6 +1,7 @@
 @stylesheet /resources/hexagon/__version__/hexagon.css
 @script /resources/hexagon/__version__/hexagon.js
 @inline ../../../shared/common.um
+@keywords modal popup overlay window component
 @titlebar Modal
 
 @div .dx-content

--- a/content/pages/modules/morph-section/index.um
+++ b/content/pages/modules/morph-section/index.um
@@ -1,6 +1,7 @@
 @stylesheet /resources/hexagon/__version__/hexagon.css
 @script /resources/hexagon/__version__/hexagon.js
 @inline ../../../shared/common.um
+@keywords morph section transform util
 @titlebar Morph Section
 
 @div .dx-content

--- a/content/pages/modules/morphs/index.um
+++ b/content/pages/modules/morphs/index.um
@@ -1,6 +1,7 @@
 @stylesheet /resources/hexagon/__version__/hexagon.css
 @script /resources/hexagon/__version__/hexagon.js
 @inline ../../../shared/common.um
+@keywords morphs animation tranition util
 @titlebar Morphs
 
 @div .dx-content

--- a/content/pages/modules/notice/index.um
+++ b/content/pages/modules/notice/index.um
@@ -1,6 +1,7 @@
 @stylesheet /resources/hexagon/__version__/hexagon.css
 @script /resources/hexagon/__version__/hexagon.js
 @inline ../../../shared/common.um
+@keywords notice warning info panel styles
 @titlebar Notice
 
 @div .dx-content

--- a/content/pages/modules/notify/index.um
+++ b/content/pages/modules/notify/index.um
@@ -1,6 +1,7 @@
 @stylesheet /resources/hexagon/__version__/hexagon.css
 @script /resources/hexagon/__version__/hexagon.js
 @inline ../../../shared/common.um
+@keywords notify notification alert message component
 @titlebar Notify
 
 @div .dx-content

--- a/content/pages/modules/number-picker/index.um
+++ b/content/pages/modules/number-picker/index.um
@@ -1,6 +1,7 @@
 @stylesheet /resources/hexagon/__version__/hexagon.css
 @script /resources/hexagon/__version__/hexagon.js
 @inline ../../../shared/common.um
+@keywords number picker component
 @titlebar Number Picker
 
 @div .dx-content

--- a/content/pages/modules/paginator/index.um
+++ b/content/pages/modules/paginator/index.um
@@ -1,6 +1,7 @@
 @stylesheet /resources/hexagon/__version__/hexagon.css
 @script /resources/hexagon/__version__/hexagon.js
 @inline ../../../shared/common.um
+@keywords paginator component
 @titlebar Paginator
 
 @div .dx-content

--- a/content/pages/modules/palette/index.um
+++ b/content/pages/modules/palette/index.um
@@ -1,6 +1,7 @@
 @stylesheet /resources/hexagon/__version__/hexagon.css
 @script /resources/hexagon/__version__/hexagon.js
 @inline ../../../shared/common.um
+@keywords palette util
 @titlebar Palette
 
 @div .dx-content

--- a/content/pages/modules/picker/index.um
+++ b/content/pages/modules/picker/index.um
@@ -1,6 +1,7 @@
 @stylesheet /resources/hexagon/__version__/hexagon.css
 @script /resources/hexagon/__version__/hexagon.js
 @inline ../../../shared/common.um
+@keywords picker component
 @titlebar Picker
 
 @div .dx-content

--- a/content/pages/modules/pivot-table/index.um
+++ b/content/pages/modules/pivot-table/index.um
@@ -1,6 +1,7 @@
 @stylesheet /resources/hexagon/__version__/hexagon.css
 @script /resources/hexagon/__version__/hexagon.js
 @inline ../../../shared/common.um
+@keywords pivot table component
 @titlebar Pivot Table
 
 @div .dx-content

--- a/content/pages/modules/plot/index.um
+++ b/content/pages/modules/plot/index.um
@@ -1,6 +1,7 @@
 @stylesheet /resources/hexagon/__version__/hexagon.css
 @script /resources/hexagon/__version__/hexagon.js
 @inline ../../../shared/common.um
+@keywords plot graph pie chart bar series band line area scatter axis axes sparkline spark component
 @titlebar Plot
 
 @div .dx-content

--- a/content/pages/modules/pointer-events/index.um
+++ b/content/pages/modules/pointer-events/index.um
@@ -1,6 +1,7 @@
 @stylesheet /resources/hexagon/__version__/hexagon.css
 @script /resources/hexagon/__version__/hexagon.js
 @inline ../../../shared/common.um
+@keywords pointer events util
 @titlebar Pointer Events
 
 @div .dx-content

--- a/content/pages/modules/preferences/index.um
+++ b/content/pages/modules/preferences/index.um
@@ -1,6 +1,7 @@
 @stylesheet /resources/hexagon/__version__/hexagon.css
 @script /resources/hexagon/__version__/hexagon.js
 @inline ../../../shared/common.um
+@keywords preferences user util
 @titlebar Preferences
 
 @div .dx-content

--- a/content/pages/modules/progress-bar/index.um
+++ b/content/pages/modules/progress-bar/index.um
@@ -1,6 +1,7 @@
 @stylesheet /resources/hexagon/__version__/hexagon.css
 @script /resources/hexagon/__version__/hexagon.js
 @inline ../../../shared/common.um
+@keywords progress bar component
 @titlebar Progress Bar
 
 @div .dx-content

--- a/content/pages/modules/request/index.um
+++ b/content/pages/modules/request/index.um
@@ -1,6 +1,7 @@
 @stylesheet /resources/hexagon/__version__/hexagon.css
 @script /resources/hexagon/__version__/hexagon.js
 @inline ../../../shared/common.um
+@keywords request util
 @titlebar Request
 
 @div .dx-content

--- a/content/pages/modules/resize-events/index.um
+++ b/content/pages/modules/resize-events/index.um
@@ -1,6 +1,7 @@
 @stylesheet /resources/hexagon/__version__/hexagon.css
 @script /resources/hexagon/__version__/hexagon.js
 @inline ../../../shared/common.um
+@keywords resize events util
 @titlebar Resize Events
 
 @div .dx-content

--- a/content/pages/modules/search-dom/index.um
+++ b/content/pages/modules/search-dom/index.um
@@ -1,6 +1,7 @@
 @stylesheet /resources/hexagon/__version__/hexagon.css
 @script /resources/hexagon/__version__/hexagon.js
 @inline ../../../shared/common.um
+@keywords search dom util
 @titlebar Search Dom
 
 @div .dx-content

--- a/content/pages/modules/select/index.um
+++ b/content/pages/modules/select/index.um
@@ -1,6 +1,7 @@
 @stylesheet /resources/hexagon/__version__/hexagon.css
 @script /resources/hexagon/__version__/hexagon.js
 @inline ../../../shared/common.um
+@keywords select component
 @titlebar Select
 
 @div .dx-content

--- a/content/pages/modules/selection/index.um
+++ b/content/pages/modules/selection/index.um
@@ -1,6 +1,7 @@
 @stylesheet /resources/hexagon/__version__/hexagon.css
 @script /resources/hexagon/__version__/hexagon.js
 @inline ../../../shared/common.um
+@keywords selection dom query find util
 @titlebar Selection
 
 @div .dx-content

--- a/content/pages/modules/set/index.um
+++ b/content/pages/modules/set/index.um
@@ -1,6 +1,7 @@
 @stylesheet /resources/hexagon/__version__/hexagon.css
 @script /resources/hexagon/__version__/hexagon.js
 @inline ../../../shared/common.um
+@keywords set collection util
 @titlebar Set
 
 @div .dx-content

--- a/content/pages/modules/side-collapsible/index.um
+++ b/content/pages/modules/side-collapsible/index.um
@@ -1,6 +1,7 @@
 @stylesheet /resources/hexagon/__version__/hexagon.css
 @script /resources/hexagon/__version__/hexagon.js
 @inline ../../../shared/common.um
+@keywords side collapsible component
 @titlebar Side Collapsible
 
 @div .dx-content

--- a/content/pages/modules/sidebar/index.um
+++ b/content/pages/modules/sidebar/index.um
@@ -1,6 +1,7 @@
 @stylesheet /resources/hexagon/__version__/hexagon.css
 @script /resources/hexagon/__version__/hexagon.js
 @inline ../../../shared/common.um
+@keywords sidebar component
 @titlebar Sidebar
 
 @div .dx-content

--- a/content/pages/modules/slider/index.um
+++ b/content/pages/modules/slider/index.um
@@ -1,6 +1,7 @@
 @stylesheet /resources/hexagon/__version__/hexagon.css
 @script /resources/hexagon/__version__/hexagon.js
 @inline ../../../shared/common.um
+@keywords slider component
 @titlebar Slider
 
 @div .dx-content

--- a/content/pages/modules/sort/index.um
+++ b/content/pages/modules/sort/index.um
@@ -1,6 +1,7 @@
 @stylesheet /resources/hexagon/__version__/hexagon.css
 @script /resources/hexagon/__version__/hexagon.js
 @inline ../../../shared/common.um
+@keywords sort util
 @titlebar Sort
 
 @div .dx-content

--- a/content/pages/modules/spinner/index.um
+++ b/content/pages/modules/spinner/index.um
@@ -1,6 +1,7 @@
 @stylesheet /resources/hexagon/__version__/hexagon.css
 @script /resources/hexagon/__version__/hexagon.js
 @inline ../../../shared/common.um
+@keywords spinner loading styles
 @titlebar Spinner
 
 @div .dx-content

--- a/content/pages/modules/sticky-table-headers/index.um
+++ b/content/pages/modules/sticky-table-headers/index.um
@@ -1,6 +1,7 @@
 @stylesheet /resources/hexagon/__version__/hexagon.css
 @script /resources/hexagon/__version__/hexagon.js
 @inline ../../../shared/common.um
+@keywords sticky table headers component
 @titlebar Sticky Table Headers
 
 @div .dx-content

--- a/content/pages/modules/table/index.um
+++ b/content/pages/modules/table/index.um
@@ -1,6 +1,7 @@
 @stylesheet /resources/hexagon/__version__/hexagon.css
 @script /resources/hexagon/__version__/hexagon.js
 @inline ../../../shared/common.um
+@keywords table styles
 @titlebar Table
 
 @div .dx-content

--- a/content/pages/modules/tabs/index.um
+++ b/content/pages/modules/tabs/index.um
@@ -1,6 +1,7 @@
 @stylesheet /resources/hexagon/__version__/hexagon.css
 @script /resources/hexagon/__version__/hexagon.js
 @inline ../../../shared/common.um
+@keywords tabs component
 @titlebar Tabs
 
 @div .dx-content

--- a/content/pages/modules/tag-input/index.um
+++ b/content/pages/modules/tag-input/index.um
@@ -1,6 +1,7 @@
 @stylesheet /resources/hexagon/__version__/hexagon.css
 @script /resources/hexagon/__version__/hexagon.js
 @inline ../../../shared/common.um
+@keywords tag input component
 @titlebar Tag Input
 
 @div .dx-content

--- a/content/pages/modules/time-picker/index.um
+++ b/content/pages/modules/time-picker/index.um
@@ -1,6 +1,7 @@
 @stylesheet /resources/hexagon/__version__/hexagon.css
 @script /resources/hexagon/__version__/hexagon.js
 @inline ../../../shared/common.um
+@keywords time picker component
 @titlebar Time Picker
 
 @div .dx-content

--- a/content/pages/modules/time-slider/index.um
+++ b/content/pages/modules/time-slider/index.um
@@ -1,6 +1,7 @@
 @stylesheet /resources/hexagon/__version__/hexagon.css
 @script /resources/hexagon/__version__/hexagon.js
 @inline ../../../shared/common.um
+@keywords time slider component
 @titlebar Time Slider
 
 @div .dx-content

--- a/content/pages/modules/titlebar/index.um
+++ b/content/pages/modules/titlebar/index.um
@@ -1,6 +1,7 @@
 @stylesheet /resources/hexagon/__version__/hexagon.css
 @script /resources/hexagon/__version__/hexagon.js
 @inline ../../../shared/common.um
+@keywords titlebar component
 @titlebar Titlebar
 
 @div .dx-content

--- a/content/pages/modules/toggle-button/index.um
+++ b/content/pages/modules/toggle-button/index.um
@@ -1,6 +1,7 @@
 @stylesheet /resources/hexagon/__version__/hexagon.css
 @script /resources/hexagon/__version__/hexagon.js
 @inline ../../../shared/common.um
+@keywords toggle button component
 @titlebar Toggle Button
 
 @div .dx-content

--- a/content/pages/modules/toggle/index.um
+++ b/content/pages/modules/toggle/index.um
@@ -1,6 +1,7 @@
 @stylesheet /resources/hexagon/__version__/hexagon.css
 @script /resources/hexagon/__version__/hexagon.js
 @inline ../../../shared/common.um
+@keywords toggle component
 @titlebar Toggle
 
 @div .dx-content

--- a/content/pages/modules/transition/index.um
+++ b/content/pages/modules/transition/index.um
@@ -1,6 +1,7 @@
 @stylesheet /resources/hexagon/__version__/hexagon.css
 @script /resources/hexagon/__version__/hexagon.js
 @inline ../../../shared/common.um
+@keywords transition util
 @titlebar Transition
 
 @div .dx-content

--- a/content/pages/modules/tree/index.um
+++ b/content/pages/modules/tree/index.um
@@ -1,6 +1,7 @@
 @stylesheet /resources/hexagon/__version__/hexagon.css
 @script /resources/hexagon/__version__/hexagon.js
 @inline ../../../shared/common.um
+@keywords tree component
 @titlebar Tree
 
 @div .dx-content

--- a/content/pages/modules/user-facing-text/index.um
+++ b/content/pages/modules/user-facing-text/index.um
@@ -1,6 +1,7 @@
 @stylesheet /resources/hexagon/__version__/hexagon.css
 @script /resources/hexagon/__version__/hexagon.js
 @inline ../../../shared/common.um
+@keywords user facing text localisation util
 @titlebar User Facing Text
 
 @div .dx-content

--- a/content/pages/modules/util/index.um
+++ b/content/pages/modules/util/index.um
@@ -1,6 +1,7 @@
 @stylesheet /resources/hexagon/__version__/hexagon.css
 @script /resources/hexagon/__version__/hexagon.js
 @inline ../../../shared/common.um
+@keywords util util
 @titlebar Util
 
 @div .dx-content

--- a/content/pages/modules/view/index.um
+++ b/content/pages/modules/view/index.um
@@ -1,6 +1,7 @@
 @stylesheet /resources/hexagon/__version__/hexagon.css
 @script /resources/hexagon/__version__/hexagon.js
 @inline ../../../shared/common.um
+@keywords view join data dom util
 @titlebar View
 
 @div .dx-content

--- a/transforms/transforms.js
+++ b/transforms/transforms.js
@@ -27,7 +27,7 @@ exports.module = function (entity, page, transforms) {
       .add(page.create('div').class('docs-module-changelog-link')
         .add(page.create('a').text('Changelog').attr('href', '/docs/' + module + '/changelog/'))))
 
-  if (entity.content.filter(function (e) {return e}).length) {
+  if (entity.content.filter(function (e) { return e }).length) {
     if (entity.has('description')) {
       moduleContainer = moduleContainer.add(entity.select('description').transform(transforms))
     } else {
@@ -119,4 +119,12 @@ exports.example = function (entity, page, transforms) {
   return page.create('div').class('docs-example')
     .add(body)
     .add(code)
+}
+
+exports.keywords = function (entity, page, transforms) {
+  var hexagonKeywords = 'hexagon, hexagon js, hexagon-js, hexagon.js'
+  var keywords = entity.ps() ? entity.ps(', ') + ', ' : ''
+  return page.create('meta')
+    .attr('name', 'keywords')
+    .attr('content', keywords + hexagonKeywords)
 }


### PR DESCRIPTION
The theory is that the docs will behave better in search results - currently the pages that turn up when searching are seemingly quite random. 
This should help improve searching at least on the keywords defined for each module.
It should also improve page ranking when searching for `hexagon js` etc. (hopefully)
