### PR TITLE
Request module doc clarification

### DIFF
--- a/content/modules/request/versions/0.11.0.um
+++ b/content/modules/request/versions/0.11.0.um
@@ -3,7 +3,17 @@
     @function hx.xhr
       @removed: Given a more descriptive name: hx.request
       @param url [Any]
-      @param? data [Any]
+      @param data [Any]
+      @param callback [Function]
+        @param error [Object]
+        @param response [Object / Any]
+        @param source [Any]
+        @param? index [Number]
+      @param? options [Object]
+
+    @function hx.xhr
+      @removed: Given a more descriptive name: hx.request
+      @param url [Any]
       @param callback [Function]
         @param error [Object]
         @param response [Object / Any]

--- a/content/modules/request/versions/0.9.0.um
+++ b/content/modules/request/versions/0.9.0.um
@@ -72,11 +72,128 @@
               }
             ]
 
-      @param? data [Any]
+      @param data [Any]
         @description
-          The data to send with the request. It can be a string or a javascript object.
-          Objects will be passed through JSON.stringify before being sent with the request and strings will be passed straight through.
-          If data is not needed, the second parameter should be the callback function.
+          @p The data to send with the request. It can be a string or a javascript object.
+          @p Objects will be passed through JSON.stringify before being sent with the request and strings will be passed straight through.
+
+      @param callback [Function]
+        @description
+          The function to call when a request is complete.
+          For string and object based urls, the callback will be called once when the url has finished.
+          For arrays, the callback will be called for each response with an index and then again once all the requests have returned with an array containing all the responses.
+
+        @param error [Object]
+          The error returned from the request (if present). This will include any status related errors as well as errors with the formatter.
+          If the error is returned from the request, the error returned will be the entire response object.
+          If the error is returned from the formatter, the error will be a javascript Error object.
+          If an error is present, the response will always be undefined.
+        @param response [Object / Any]
+          The response from the request. If a formatter is not defined, the response will contain the entire request, making the responseText, status and other properties available.
+          If a formatter is defined, only the result of the formatter is returned.
+        @param source [Any]
+          @description
+            The source url/data that was sent with the request.
+            If the source is a url string and there is no data provided, the source will be returned as a string. If data is provided, the source will be in the form of an object.
+            @codeblock js
+              // No data provided
+              'http://your-server/'
+
+              // Data provided
+              {
+                url: 'http://your-server/'
+                data: {
+                  your: 'data'
+                }
+              }
+
+        @param? index [Number]
+          The index of the response with regard to the passed in url array.
+          If the requests return out of order, the index will always match the index of the source url in the url array.
+          When all of the array of urls have returned, the callback will be called with an index of -1 and will be passed an array of all the responses and an array of all the sources, in the same order that they were specified in the url array passed in to the request.
+      @param? options [Object]
+        The options for the request
+        @property contentType [String]
+          The content type for the request. This value will be passed to the headers and used as the default response type as well as the 'Content-Type' and 'accepts' headers. These values can be overridden with the headers option if required. The content type is not defined by default.
+        @property responseType [String]: The desired response type for the request.
+        @property requestType [String]: The http request type for the request. The default value is 'GET' if no data is provided and 'POST' if data is provided.
+        @property formatter [Function]
+          The function to use when formatting the response data. It can be used to get the response text so the callback does not have to or convert the response into a useful format.
+          @param response [Object]: The unformatted response from the request.
+          @returns Any: The formatted response object
+        @property headers [Object]
+          @description
+            An object that is used to populate the headers object with explicit values.
+            It can be used to override or specify headers other than 'Content-Type' or 'accepts'
+
+            @codeblock js
+              headers = {
+                'Content-Type': 'text/plain', // explicitly set the content type ot text/plain, can also be set with the 'contentType' option
+                'accepts': 'text/plain,*/*', // explicitly set the accepts header.
+                'custom': 'dave' // set a custom header
+              }
+
+    @function hx.xhr
+      @deprecated: Given a more descriptive name: hx.request
+      @description
+        The core part of Hexagon's request API. This function lets you request data from a server with various options as well as making multiple requests with one call.
+      @param url [Any]
+        @description
+          The url to request data from. The URL can be in several formats which can be used interchangably. The below examples illustrate the different types of url that can be specified
+          @h3: String
+          Any standard url string.
+          @codeblock js
+            'http://your-server/'
+
+          @h3: Object
+          An object with url and data properties.
+          @codeblock js
+            // Object with url
+            {
+              url: 'http://your-server/'
+            }
+
+            // Object with url and data
+            {
+              url: 'http://your-server/',
+              data: {
+                your: 'data'
+              }
+            }
+
+          @h3: Array
+          An array of string or object urls. The data property can be specified per-url or using the data parameter. Data specified on a url will always override the data passed in with the params.
+          @codeblock js
+
+            // Array of strings
+            [
+              'http://your-server-1/',
+              'http://your-server-1/'
+            ]
+
+            // Array of objects
+            [
+              {
+                url: 'http://your-server-1/'
+              },
+              {
+                url: 'http://your-server-2/'
+              }
+            ]
+
+            // Mixed Array
+            [
+              'http://your-server/',
+              {
+                url: 'http://your-server/'
+              },
+              {
+                url: 'http://your-server/'
+                data: {
+                  a: 1
+                }
+              }
+            ]
 
       @param callback [Function]
         @description
@@ -197,9 +314,129 @@
               }
             ]
 
-      @param? data [Any]
+      @param data [Any]
         @description
-          The data to send in the body of the request. It can be a string or a javascript object. Objects will be passed through JSON.stringify before being sent with the request and strings will be passed straight through. If data is not needed, the second parameter should be the callback function.
+          @p: The data to send in the body of the request. It can be a string or a javascript object.
+          @p: Objects will be passed through JSON.stringify before being sent with the request and strings will be passed straight through.
+
+      @param callback [Function]
+        @description
+          The function to call when a request is complete.
+
+        @param error [Object]
+          The error returned from the request (if present). This will include any status related errors as well as errors with the formatter.
+          If the error is returned from the request, the error returned will be the entire response object.
+          If the error is returned from the formatter, the error will be a javascript Error object.
+          If an error is present, the response will always be undefined.
+        @param response [Object / Any]
+          The response from the request. If a formatter is not defined, the response will contain the entire request, making the responseText, status and other properties available.
+          If a formatter is defined, only the result of the formatter is returned.
+        @param source [Any]
+          @description
+            The source url/data that was sent with the request.
+            If the source is a url string and there is no data provided, the source will be returned as a string. If data is provided, the source will be in the form of an object.
+            @codeblock js
+              // No data provided
+              'http://your-server/'
+
+              // Data provided
+              {
+                url: 'http://your-server/'
+                data: {
+                  your: 'data'
+                }
+              }
+
+            If this is a request to muliple urls and this is the final call to the callback, then the source will be an array of all the source objects
+
+        @param? index [Number]
+          The index of the response with regard to the passed in url array.
+          If the requests return out of order, the index will always match the index of the source url in the url array.
+          When all of the array of urls have returned, the callback will be called with an index of -1 and will be passed an array of all the responses and an array of all the sources, in the same order that they were specified in the url array passed in to the request.
+      @param? options [Object]
+        The options for the request
+        @property contentType [String]
+          The content type for the request. This value will be passed to the headers and used as the default response type as well as the 'Content-Type' and 'accepts' headers. These values can be overridden with the headers option if required. The content type is not defined by default.
+        @property responseType [String]: The desired response type for the request.
+        @property requestType [String]: The http request type for the request. The default value is 'GET' if no data is provided and 'POST' if data is provided.
+        @property formatter [Function]
+          The function to use when formatting the response data. It can be used to get the response text so the callback does not have to or convert the response into a useful format.
+          @param response [Object]: The unformatted response from the request.
+          @returns Any: The formatted response object
+        @property headers [Object]
+          @description
+            An object that is used to populate the headers object with explicit values.
+            It can be used to override or specify headers other than 'Content-Type' or 'accepts'
+
+            @codeblock js
+              headers = {
+                'Content-Type': 'text/plain', // explicitly set the content type ot text/plain, can also be set with the 'contentType' option
+                'accepts': 'text/plain,*/*', // explicitly set the accepts header.
+                'custom': 'dave' // set a custom header
+              }
+
+    @function hx.request
+      @added
+      @description
+        Makes a http request to the resource specified.
+
+      @param url [Any]
+        @description
+          The url to request data from. The URL can be in several formats which can be used interchangably. The below examples illustrate the different types of url that can be specified
+          @h3: String
+          Any standard url string.
+          @codeblock js
+            'http://your-server/'
+
+          @h3: Object
+          An object with url and data properties.
+          @codeblock js
+            // Object with url
+            {
+              url: 'http://your-server/'
+            }
+
+            // Object with url and data
+            {
+              url: 'http://your-server/',
+              data: {
+                your: 'data'
+              }
+            }
+
+          @h3: Array
+          An array of string or object urls. The data property can be specified per-url or using the data parameter. Data specified on a url will always override the data passed in with the params.
+          @codeblock js
+
+            // Array of strings
+            [
+              'http://your-server-1/',
+              'http://your-server-1/'
+            ]
+
+            // Array of objects
+            [
+              {
+                url: 'http://your-server-1/'
+              },
+              {
+                url: 'http://your-server-2/'
+              }
+            ]
+
+            // Mixed Array
+            [
+              'http://your-server/',
+              {
+                url: 'http://your-server/'
+              },
+              {
+                url: 'http://your-server/'
+                data: {
+                  a: 1
+                }
+              }
+            ]
 
       @param callback [Function]
         @description
@@ -320,11 +557,127 @@
                 }
               ]
 
-        @param? data [Any]
+        @param data [Any]
           @description
             @p: The data to send with the request. It can be a string or a javascript object.
             @p: Objects will be passed through JSON.stringify before being sent with the request and strings will be passed straight through.
-            @p: If data is not needed, the second parameter should be the callback function.
+
+        @param callback [Function]
+          @description
+            @p: The function to call when a request is complete.
+            @p: For string and object based urls, the callback will be called once when the url has finished.
+            @p: For arrays, the callback will be called for each response with an index and then again once all the requests have returned with an array containing all the responses.
+
+          @param error [Object]
+            @description
+              @p: The error returned from the request (if present). This will include any status related errors as well as errors with the formatter.
+              @p: If the error is returned from the request, the error returned will be the entire response object.
+              @p: If the error is returned from the formatter, the error will be a javascript Error object.
+              @p: If an error is present, the response will always be undefined.
+          @param response [Object / Any]
+            @description
+              @p: The response from the request. If a formatter is not defined, the response will contain the entire request, making the responseText, status and other properties available.
+              @p: If a formatter is defined, only the result of the formatter is returned.
+          @param source [Any]
+            @description
+              @p: The source url/data that was sent with the request.
+              @p: If the source is a url string and there is no data provided, the source will be returned as a string. If data is provided, the source will be in the form of an object.
+              @codeblock js
+                // No data provided
+                'http://your-server/'
+
+                // Data provided
+                {
+                  url: 'http://your-server/'
+                  data: {
+                    your: 'data'
+                  }
+                }
+
+          @param? index [Number]
+            @description
+              @p: The index of the response with regard to the passed in url array.
+              @p: If the requests return out of order, the index will always match the index of the source url in the url array.
+              @p: When all of the array of urls have returned, the callback will be called with an index of -1 and will be passed an array of all the responses and an array of all the sources, in the same order that they were specified in the url array passed in to the request.
+
+        @param? options [Object]
+          @description
+            @p: The options for the request
+          @property contentType [String]:The content type for the request. This value will be passed to the headers and used as the default response type as well as the 'Content-Type' and 'accepts' headers. These values can be overridden with the headers option if required. The content type is not defined by default.
+          @property responseType [String]: The desired response type for the request.
+          @property requestType [String]: The http request type for the request. The default value is 'GET' if no data is provided and 'POST' if data is provided.
+          @property headers [Object]
+            @description
+              @p: An object that is used to populate the headers object with explicit values.
+              @p: It can be used to override or specify headers other than 'Content-Type' or 'accepts'
+              @codeblock js
+                headers = {
+                  'Content-Type': 'text/plain', // explicitly set the content type ot text/plain, can also be set with the 'contentType' option
+                  'accepts': 'text/plain,*/*', // explicitly set the accepts header.
+                  'custom': 'dave' // set a custom header
+                }
+
+      @function {{ps}}
+        @description
+          A wrapper for hx.request that supplies a formatter to return {{cs}} instead of the response object.
+
+        @param url [Any]
+          @description
+            @p: The url to request data from. The URL can be in several formats which can be used interchangably. The below examples illustrate the different types of url that can be specified
+            @h3: String
+            @p: Any standard url string.
+            @codeblock js
+              'http://your-server/'
+
+            @h3: Object
+            @p: An object with url and data properties.
+            @codeblock js
+              // Object with url
+              {
+                url: 'http://your-server/'
+              }
+
+              // Object with url and data
+              {
+                url: 'http://your-server/',
+                data: {
+                  your: 'data'
+                }
+              }
+
+            @h3: Array
+            @p: An array of string or object urls. The data property can be specified per-url or using the data parameter. Data specified on a url will always override the data passed in with the params.
+            @codeblock js
+
+              // Array of strings
+              [
+                'http://your-server-1/',
+                'http://your-server-1/'
+              ]
+
+              // Array of objects
+              [
+                {
+                  url: 'http://your-server-1/'
+                },
+                {
+                  url: 'http://your-server-2/'
+                }
+              ]
+
+              // Mixed Array
+              [
+                'http://your-server/',
+                {
+                  url: 'http://your-server/'
+                },
+                {
+                  url: 'http://your-server/'
+                  data: {
+                    a: 1
+                  }
+                }
+              ]
 
         @param callback [Function]
           @description

--- a/content/modules/request/versions/0.9.0.um
+++ b/content/modules/request/versions/0.9.0.um
@@ -74,8 +74,8 @@
 
       @param data [Any]
         @description
-          @p The data to send with the request. It can be a string or a javascript object.
-          @p Objects will be passed through JSON.stringify before being sent with the request and strings will be passed straight through.
+          @p: The data to send with the request. It can be a string or a javascript object.
+          @p: Objects will be passed through JSON.stringify before being sent with the request and strings will be passed straight through.
 
       @param callback [Function]
         @description


### PR DESCRIPTION
resolves #43 

Documentation for each function is duplicated showing the version with the `data` parameter for each first and then without.
