### PR TITLE
Add the hexagon demo pages to the site

### DIFF
--- a/build/demo.js
+++ b/build/demo.js
@@ -1,0 +1,25 @@
+const hexagon = require('hexagon-js')
+const path = require('path')
+
+function getFolder (which) {
+  return path.join('target', 'themes', which)
+}
+
+function buildDemo(which) {
+  console.log('Building', which)
+  const dest = getFolder(which)
+  hexagon.demo({
+    dest,
+    serverEnabled: false
+  })
+  return hexagon[which].build({ dest })
+    .then(() => console.log('Built', which))
+}
+
+Promise.all([
+  buildDemo('light'),
+  buildDemo('dark')
+])
+  .then(() => process.exit(0))
+  .catch(() => process.exit(1))
+

--- a/content/resources/titlebar.js
+++ b/content/resources/titlebar.js
@@ -14,6 +14,7 @@ function setupMenu (node, meta) {
     .add(dx.detached('a').class('docs-dropdown-link').attr('href', '/guide/core-concepts/').text('Core concepts'))
     .add(dx.detached('a').class('docs-dropdown-link').attr('href', '/guide/printing/').text('Printing'))
     .add(dx.detached('a').class('docs-dropdown-link').attr('href', '/examples/').text('Examples'))
+    .add(dx.detached('a').class('docs-dropdown-link').attr('href', '/themes/').text('Themes'))
     // .add(dx.detached('h3').text('Design patterns'))
     // .add(dx.detached('a').class('docs-dropdown-link').attr('href', '/guide/general-guidelines/').text('General guidelines'))
     // .add(dx.detached('a').class('docs-dropdown-link').attr('href', '/guide/page-layout/').text('Page layout'))

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "main": "./build/index.js",
   "scripts": {
     "postinstall": "node build/index.js postinstall",
-    "start": "node build/index.js",
+    "start": "node build/demo.js && node build/index.js",
     "clean": "rm -r target; true",
     "build-all": "node build/index.js build-all",
     "build-examples": "node build/buildexamples.js",


### PR DESCRIPTION
The current site doesn't have an example of the themes. This change adds the light/dark demos under the 'themes' directory.